### PR TITLE
Added get executions to flytectl

### DIFF
--- a/cmd/get/execution.go
+++ b/cmd/get/execution.go
@@ -1,0 +1,68 @@
+package get
+
+import (
+	"context"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/lyft/flytestdlib/logger"
+
+	"github.com/lyft/flytectl/cmd/config"
+	cmdCore "github.com/lyft/flytectl/cmd/core"
+	"github.com/lyft/flytectl/pkg/printer"
+)
+
+var executionColumns = []printer.Column{
+	{"Name", "$.id.name"},
+	{"Workflow Name", "$.closure.workflowId.name"},
+	{"Type", "$.closure.workflowId.resourceType"},
+	{"Phase", "$.closure.phase"},
+	{"Started", "$.closure.startedAt"},
+	{"Elapsed Time", "$.closure.duration"},
+}
+
+func ExecutionToProtoMessages(l []*admin.Execution) []proto.Message {
+	messages := make([]proto.Message, 0, len(l))
+	for _, m := range l {
+		messages = append(messages, m)
+	}
+	return messages
+}
+
+func getExecutionFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
+	adminPrinter := printer.Printer{}
+	var executions []* admin.Execution
+	if len(args) > 0 {
+		name := args[0]
+		execution, err := cmdCtx.AdminClient().GetExecution(ctx, &admin.WorkflowExecutionGetRequest{
+			Id: &core.WorkflowExecutionIdentifier{
+				Project: config.GetConfig().Project,
+				Domain:  config.GetConfig().Domain,
+				Name:    name,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		executions = append(executions, execution)
+	} else {
+		executionList, err := cmdCtx.AdminClient().ListExecutions(ctx, &admin.ResourceListRequest{
+			Limit: 100,
+			Id: &admin.NamedEntityIdentifier{
+				Project: config.GetConfig().Project,
+				Domain:  config.GetConfig().Domain,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		executions = executionList.Executions
+	}
+	logger.Infof(ctx, "Retrieved %v executions", len(executions))
+	err := adminPrinter.Print(config.GetConfig().MustOutputFormat(), executionColumns, ExecutionToProtoMessages(executions)...)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -18,6 +18,7 @@ func CreateGetCommand() *cobra.Command {
 		"task":       {CmdFunc: getTaskFunc, Aliases: []string{"tasks"}},
 		"workflow":   {CmdFunc: getWorkflowFunc, Aliases: []string{"workflows"}},
 		"launchplan": {CmdFunc: getLaunchPlanFunc, Aliases: []string{"launchplans"}},
+		"execution":  {CmdFunc: getExecutionFunc, Aliases: []string{"executions"}},
 	}
 
 	cmdcore.AddCommands(getCmd, getResourcesFuncs)


### PR DESCRIPTION
Usage :
**1] Returns list of executions in a project domain**

```
bin/flytectl get executions  -d development  -p flytesnacks
INFO[0000] Using config file: [config.yaml]
INFO[0000] Config section [adminutils] updated. No update handler registered.  src="viper.go:318"
INFO[0000] Config section [logger] updated. Firing updated event.  src="viper.go:320"
| NAME (4)   | WORKFLOW NAME                                                      | TYPE     | PHASE     | STARTED                        | ELAPSED TIME  |
 ------------ -------------------------------------------------------------------- ---------- ----------- -------------------------------- ---------------
| h5i7q5h9he | recipes.07_juptyer_notebooks.whole_square_workflow.whole_square_wf | WORKFLOW | SUCCEEDED | 2021-01-19T10:42:41.467046Z    | 62.763573800s |
| lqi9q9l8fb | recipes.07_juptyer_notebooks.whole_square_workflow.whole_square_wf | WORKFLOW | ABORTED   | 2021-01-19T10:48:12.546933900Z | 13.067154500s |
| vcfy9487ud | recipes.07_juptyer_notebooks.whole_square_workflow.whole_square_wf | WORKFLOW | ABORTED   | 2021-01-20T04:28:08.272178800Z | 8.317607300s  |
| zgxdehv84b | recipes.07_juptyer_notebooks.whole_square_workflow.whole_square_wf | WORKFLOW | ABORTED   | 2021-01-19T15:34:38.757407800Z | 18.213011300s |
4 rows
```

**2] Returns a single execution based on its NAME ($.id.name)**
```
bin/flytectl get executions  h5i7q5h9he -d development  -p flytesnacks
INFO[0000] Using config file: [config.yaml]
INFO[0000] Config section [admin] updated. Firing updated event.  src="viper.go:320"
INFO[0000] Config section [adminutils] updated. No update handler registered.  src="viper.go:318"
INFO[0000] Config section [logger] updated. Firing updated event.  src="viper.go:320"
| NAME       | WORKFLOW NAME                                                      | TYPE     | PHASE     | STARTED                     | ELAPSED TIME  |
 ------------ -------------------------------------------------------------------- ---------- ----------- ----------------------------- ---------------
| h5i7q5h9he | recipes.07_juptyer_notebooks.whole_square_workflow.whole_square_wf | WORKFLOW | SUCCEEDED | 2021-01-19T10:42:41.467046Z | 62.763573800s |
1 rows
```

**3] For an invalid name it currently prints the error and display help
and panic trace. This needs to be enhanced to not show the trace if its
user error**

```
bin/flytectl get executions  WORKFLOW -d development  -p flytesnacks
INFO[0000] Using config file: [config.yaml]
INFO[0000] Config section [logger] updated. Firing updated event.  src="viper.go:320"
Error: rpc error: code = NotFound desc = entry not found
Usage:
   get execution [flags]

Aliases:
  execution, executions

Flags:
  -h, --help   help for execution

Global Flags:
      --admin.authorizationHeader string      Custom metadata header to pass JWT
      --admin.authorizationServerUrl string   This is the URL to your IDP's authorization server'
      --admin.clientId string                 Client ID
      --admin.clientSecretLocation string     File containing the client secret
      --admin.endpoint string                 For admin types,  specify where the uri of the service is located.
      --admin.insecure                        Use insecure connection.
      --admin.maxBackoffDelay string          Max delay for grpc backoff (default "8s")
      --admin.maxRetries int                  Max number of gRPC retries (default 4)
      --admin.perRetryTimeout string          gRPC per retry timeout (default "15s")
      --admin.scopes strings                  List of scopes to request
      --admin.tokenUrl string                 Your IDPs token endpoint
      --admin.useAuth                         Whether or not to try to authenticate with options below
      --adminutils.batchSize int              Maximum number of records to retrieve per call. (default 100)
      --adminutils.maxRecords int             Maximum number of records to retrieve. (default 500)
      --config string                         config file (default is $HOME/config.yaml)
  -d, --domain string                         Specifies the Flyte project's domain.
      --logger.formatter.type string          Sets logging format type. (default "json")
      --logger.level int                      Sets the minimum logging level. (default 4)
      --logger.mute                           Mutes all logs regardless of severity. Intended for benchmarks/tests only.
      --logger.show-source                    Includes source code location in logs.
  -o, --output string                         Specifies the output type - supported formats [TABLE JSON YAML] (default "TABLE")
  -p, --project string                        Specifies the Flyte project.
      --root.domain string                    Specified the domain to work on.
      --root.output string                    Specified the output type.
      --root.project string                   Specifies the project to work on.

panic: rpc error: code = NotFound desc = entry not found

goroutine 1 [running]:
main.main()
	/Users/pmahindrakar/flyte-complete/flytectl/main.go:7 +0x47
```

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
Yet to be created
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
