### PR TITLE
Added delete execution feature for flytectl

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -1,0 +1,23 @@
+package delete
+
+import (
+	cmdcore "github.com/lyft/flytectl/cmd/core"
+
+	"github.com/spf13/cobra"
+)
+
+// CreateDeleteCommand will return delete command
+func CreateDeleteCommand() *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete various resource.",
+	}
+
+	terminateResourcesFuncs := map[string]cmdcore.CommandEntry{
+		"execution": {CmdFunc: terminateExecutionFunc, Aliases: []string{"executions"}},
+	}
+
+	cmdcore.AddCommands(deleteCmd, terminateResourcesFuncs)
+
+	return deleteCmd
+}

--- a/cmd/delete/execution.go
+++ b/cmd/delete/execution.go
@@ -1,0 +1,31 @@
+package delete
+
+import (
+	"context"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
+
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/lyft/flytestdlib/logger"
+
+	"github.com/lyft/flytectl/cmd/config"
+	cmdCore "github.com/lyft/flytectl/cmd/core"
+)
+
+
+func terminateExecutionFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
+	name := args[0]
+	logger.Infof(ctx, "Terminating execution of %v execution ", name)
+	_, err := cmdCtx.AdminClient().TerminateExecution(ctx, &admin.ExecutionTerminateRequest{
+		Id: &core.WorkflowExecutionIdentifier{
+			Project: config.GetConfig().Project,
+			Domain:  config.GetConfig().Domain,
+			Name: name,
+		},
+	})
+	if err != nil {
+		logger.Infof(ctx, "Failed in terminating execution of %v execution due to %v ", name, err)
+		return err
+	}
+	logger.Infof(ctx, "Terminated execution of %v execution ", name)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/lyft/flytectl/cmd/get"
+	"github.com/lyft/flytectl/cmd/delete"
 	"github.com/lyft/flytectl/pkg/printer"
 
 	stdConfig "github.com/lyft/flytestdlib/config"
@@ -37,6 +38,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.AddCommand(viper.GetConfigCommand())
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(get.CreateGetCommand())
+	rootCmd.AddCommand(delete.CreateDeleteCommand())
 	config.GetConfig()
 
 	return rootCmd


### PR DESCRIPTION
Deletes a workflow execution through flytectl. 

Usage: 

```
bin/flytectl delete execution kxd1i72850  -d development  -p flytesnacks
INFO[0000] Using config file: [config.yaml]             
INFO[0000] Config section [logger] updated. Firing updated event.  src="viper.go:320"
{"json":{"src":"viper.go:320"},"level":"info","msg":"Config section [admin] updated. Firing updated event.","ts":"2021-01-21T16:33:47+05:30"}
{"json":{"src":"viper.go:318"},"level":"info","msg":"Config section [root] updated. No update handler registered.","ts":"2021-01-21T16:33:47+05:30"}
{"json":{"src":"viper.go:318"},"level":"info","msg":"Config section [adminutils] updated. No update handler registered.","ts":"2021-01-21T16:33:47+05:30"}
{"json":{"src":"client.go:29"},"level":"info","msg":"Initialized Admin client","ts":"2021-01-21T16:33:47+05:30"}
{"json":{"src":"execution.go:17"},"level":"info","msg":"Terminating execution of kxd1i72850 execution ","ts":"2021-01-21T16:33:47+05:30"}
{"json":{"src":"execution.go:29"},"level":"info","msg":"Terminated execution of kxd1i72850 execution ","ts":"2021-01-21T16:33:47+05:30"}

```
```
bin/flytectl get executions  kxd1i72850 -d development  -p flytesnacks 
| NAME       | WORKFLOW NAME                                                      | TYPE     | PHASE   | STARTED                        | ELAPSED TIME  |
 ------------ -------------------------------------------------------------------- ---------- --------- -------------------------------- --------------- 
| kxd1i72850 | recipes.07_juptyer_notebooks.whole_square_workflow.whole_square_wf | WORKFLOW | ABORTED | 2021-01-21T11:03:21.148177700Z | 27.018790700s |
1 rows
```

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
Yet to be created
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
